### PR TITLE
[minor]: remove zipTypes setting (and also picky)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Add a progress counter to the preview that updates before content is loaded.
 
+## [3.4.0] - 2023-2-7
+
+Remove the settings `zipViewer.zipTypes` and `zipViewer.picky` as they don't make sense.
+
 ## [3.3.0] - 2023-2-3
 
 Add command and context menu to explorer view that allows user to GZip files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ A separate pull request should be made for each file created/changed.
 To allow the editor to recognize a new file extension, there are a couple places you need to edit.
 
 - `{package.json}.contributes.customEditors`
-- `{package.json}.contributes.configuration[0].properties.["zipViewer.zipTypes"].default` (Regular Zip only)
+- **(Deprecated)** ~~`{package.json}.contributes.configuration[0].properties.["zipViewer.zipTypes"].default` (Regular Zip only)~~
 - README ~L30 for Zip, ~L90 for GZip
 
 Once you edit those places, go ahead and make a pull request.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 An extension which allows for the manipulation of zip files in VS Code.
 
-> This extension recently hit 900 downloads.
-> It's crazy to think that 900 people have seen something that I built!
+> This extension recently hit 1000 downloads.
+> It's crazy to think that 1000 people have seen something that I built!
 >
 > If this extension has helped you at all, please consider [leaving a review][review] on the marketplace and/or [starring the repository][stargazers] on GitHub.
 
@@ -88,10 +88,7 @@ The extension will prompt you to select a zip file, then it will prompt you to c
 The contents of the zip file will be deposited in that folder.
 The new folder's name will be `<zipFileName><zipViewer.unzippedSuffix>`.
 
-The extension contributes a setting `zipViewer.zipTypes`.
-If the file you chose does not end with a string in that array, the extension will give an error message.
-You can edit this setting in the settings editor.
-This setting is ignored if `zipViewer.picky` is set to false.
+**(Deprecated)** ~~The extension contributes a setting `zipViewer.zipTypes`. If the file you chose does not end with a string in that array, the extension will give an error message.You can edit this setting in the settings editor. This setting is ignored if `zipViewer.picky` is set to false.~~
 
 #### Selective Extraction
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "%extension.description%",
   "publisher": "adamraichu",
   "icon": "logo.png",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "license": "MIT",
   "author": {
     "name": "AdamRaichu"
@@ -129,23 +129,14 @@
               "title": "%config.zipTypes.items.title%",
               "pattern": "\\.([A-Za-z0-9\\.])"
             },
-            "default": [
-              ".zip",
-              ".vsix",
-              ".mcworld",
-              ".mcpack",
-              ".mcaddon",
-              ".jar",
-              ".pbit",
-              ".pbix",
-              ".ipa",
-              ".xlsx"
-            ]
+            "deprecationMessage": "%config.zipTypes.deprecated%",
+            "default": []
           },
           "zipViewer.picky": {
             "type": "boolean",
             "markdownDescription": "%config.picky.description%",
-            "default": false
+            "default": false,
+            "deprecationMessage": "%config.zipTypes.deprecated%"
           },
           "zipViewer.unzippedSuffix": {
             "type": "string",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -13,5 +13,6 @@
   "config.gzipEditorEnabled.description": "Cuando es falso, detiene al editor de GZip de abra automáticamente y en cambio muestra un mensaje de desactivado.",
   "config.deleteOldFileWhenGzipping": "Cuando es cierto, elimina el archivo compriste cuando usas el command `zipViewer.gzip`.",
   "command.gzip": "Zip Tools: Comprimir un archivo con compresión de GZip.",
-  "command.gzip.short": "Comprimir Archivo (GZip)"
+  "command.gzip.short": "Comprimir Archivo (GZip)",
+  "config.zipTypes.deprecated": "Esta configuración tiene muy poco sentido, por lo que se ha eliminado."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,5 +13,6 @@
   "config.gzipEditorEnabled.description": "When false, stops the GZip editor from automatically decompressing and instead shows a disabled message.",
   "config.deleteOldFileWhenGzipping": "When true, deletes the file you compressed when using `zipViewer.gzip` command.",
   "command.gzip": "Zip Tools: Compress file with GZip compression.",
-  "command.gzip.short": "GZip File"
+  "command.gzip.short": "GZip File",
+  "config.zipTypes.deprecated": "This setting makes very little sense, so it has been removed."
 }

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -40,40 +40,31 @@ export default class cmds {
             if (typeof targetPath === "undefined") {
               return;
             }
-            var zipTypes = config.zipTypes;
-            for (var ext = 0; ext < zipTypes.length; ext++) {
-              if (files[0].path.endsWith(zipTypes[ext]) || !config.picky) {
-                var z = new JSZip();
-                vscode.workspace.fs.readFile(files[0]).then(function (Ui8A) {
-                  z.loadAsync(Ui8A).then(
-                    function (zip) {
-                      var keys = Object.keys(zip.files);
-                      for (var c = 0; c < keys.length; c++) {
-                        var f = zip.files[keys[c]];
-                        if (f.name.endsWith("/")) {
-                        } else {
-                          function temp(t) {
-                            t.async("uint8array").then(function (u8) {
-                              o.appendLine(`[DEBUG] Wrote ${t.name}`);
-                              vscode.workspace.fs.writeFile(vscode.Uri.joinPath(targetPath[0], files[0].path.split("/").pop() + config.unzippedSuffix, t.name), u8);
-                            });
-                          }
-                          temp(f);
-                        }
+            var z = new JSZip();
+            vscode.workspace.fs.readFile(files[0]).then(function (Ui8A) {
+              z.loadAsync(Ui8A).then(
+                function (zip) {
+                  var keys = Object.keys(zip.files);
+                  for (var c = 0; c < keys.length; c++) {
+                    var f = zip.files[keys[c]];
+                    if (f.name.endsWith("/")) {
+                    } else {
+                      function temp(t) {
+                        t.async("uint8array").then(function (u8) {
+                          o.appendLine(`[DEBUG] Wrote ${t.name}`);
+                          vscode.workspace.fs.writeFile(vscode.Uri.joinPath(targetPath[0], files[0].path.split("/").pop() + config.unzippedSuffix, t.name), u8);
+                        });
                       }
-                    },
-                    function (err) {
-                      console.error(err);
-                      vscode.window.showErrorMessage(`JSZip encountered an error trying to unzip ${files[0].path}`);
+                      temp(f);
                     }
-                  );
-                });
-                return;
-              }
-            }
-            vscode.window.showErrorMessage(
-              "Selected file does not have a supported file extension. Edit the setting `zipViewer.zipTypes` to add a file extension, but please go to the extension repository and open an issue so it can be added to the built in list."
-            );
+                  }
+                },
+                function (err) {
+                  console.error(err);
+                  vscode.window.showErrorMessage(`JSZip encountered an error trying to unzip ${files[0].path}`);
+                }
+              );
+            });
           });
       });
     });


### PR DESCRIPTION
`zipTypes` does not make sense to have. It is only used to check against opening a user-selected file, and so only adds an extra step. This is also non-functional by default.

`picky` removed as it is non-functional if `zipTypes` is removed.