### PR TITLE
[minor]: fix #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Add a progress counter to the preview that updates before content is loaded.
 
+## [3.5.0] - 2022-2-25
+
+Fix [#26](https://github.com/AdamRaichu/vscode-zip-viewer/issues/26) which was preventing contents of subfolders from being readable to downloaded zip files, although JSZip is still able to read them. This was fixed by adding/modifying these lines of code.
+
 ## [3.4.0] - 2023-2-7
 
 Remove the settings `zipViewer.zipTypes` and `zipViewer.picky` as they don't make sense.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "%extension.description%",
   "publisher": "adamraichu",
   "icon": "logo.png",
-  "version": "3.4.3",
+  "version": "3.5.0",
   "license": "MIT",
   "author": {
     "name": "AdamRaichu"

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -142,7 +142,12 @@ function zipFolder(folderToZip) {
             count++;
             if (files[d][1] === 1) {
               vscode.workspace.fs.readFile(vscode.Uri.joinPath(uri, files[d][0])).then(function (file) {
-                z.file(name, file);
+                var splitPath = name.split("/");
+                var current = z;
+                for (var i = 0; i < splitPath.length - 1; i++) {
+                  current = current.folder(splitPath[i]);
+                }
+                current.file(name, file);
                 barItem.text = `$(loading~spin) Creating zip file. Reading ${name}`;
               });
             } else if (files[d][1] === 2) {


### PR DESCRIPTION
This fixes #26 which was preventing contents of subfolders from being readable to downloaded zip files, although JSZip is still able to read them. This was fixed by adding/modifying these lines of code.

https://github.com/AdamRaichu/vscode-zip-viewer/blob/220a03ff56cb5f2021a2b4cc5f50fee31018770d/src/cmds.js#L145-L150