### PR TITLE
Optimize command `zip` using `workspace.findFiles`

### DIFF
--- a/src/cmds.js
+++ b/src/cmds.js
@@ -133,7 +133,9 @@ function zipFolder(folderToZip) {
   barItem.text = "$(loading~spin) Creating zip file...";
   barItem.show();
   function main(uri) {
-    vscode.workspace.fs.readDirectory(uri).then(
+    // vscode.workspace.fs.readDirectory(uri).then(
+    const substrLength = vscode.workspace.workspaceFolders[0].uri.path.length + 1;
+    vscode.workspace.findFiles(uri.path.substring(substrLength)).then(
       function (files) {
         for (var f in files) {
           function temp(d) {


### PR DESCRIPTION
Closes #30.

Makes zipping folders much faster. 

**(For zipping the `.github` folder of this repository):**
- Old time ~4 seconds.
- New time ~1.5 seconds.

**(For zipping the `node_modules` folder after running `npm i`):**
- Old time reached a silent error state in under 2 minutes and did not finish.
- New time ~4 minutes 40 seconds. Actually finishes.

While testing this I found out that the modules `webpack` and `underscore` are HUGE. :p